### PR TITLE
fix: improve POS tagging demo visualizations

### DIFF
--- a/demos/pos-tagging/css/pos.css
+++ b/demos/pos-tagging/css/pos.css
@@ -259,7 +259,8 @@ button {
     text-transform: uppercase;
     padding: 2px 6px;
     border-radius: 3px;
-    background: rgba(255, 255, 255, 0.7);
+    background: rgba(255, 255, 255, 0.85);
+    color: #1f2937;
 }
 
 /* POS Tag Colors - Dark mode uses brighter backgrounds, light mode uses pastel */

--- a/demos/pos-tagging/js/dependency-parser.js
+++ b/demos/pos-tagging/js/dependency-parser.js
@@ -166,7 +166,10 @@ const DependencyParser = {
             return;
         }
 
-        const width = container.clientWidth || 900;
+        const numWords = dependencies.length;
+        const minWidthPerWord = 60;
+        const containerWidth = container.clientWidth || 900;
+        const width = Math.max(containerWidth, numWords * minWidthPerWord);
         const height = 400;
         const padding = { top: 100, right: 40, bottom: 60, left: 40 };
 
@@ -175,7 +178,6 @@ const DependencyParser = {
             .attr('width', width)
             .attr('height', height);
 
-        // Create word positions
         const words = dependencies.map(d => d.word);
         const wordWidth = (width - padding.left - padding.right) / words.length;
         const positions = words.map((word, i) => ({

--- a/demos/pos-tagging/js/tree-visualizer.js
+++ b/demos/pos-tagging/js/tree-visualizer.js
@@ -14,10 +14,13 @@ const TreeVisualizer = {
             return;
         }
 
-        const width = container.clientWidth || 900;
+        const numWords = dependencies.length;
+        const minWidthPerWord = 80;
+        const containerWidth = container.clientWidth || 900;
+        const width = Math.max(containerWidth, numWords * minWidthPerWord);
         const height = 600;
 
-        // Create SVG
+        // Create SVG with dynamic width for scrolling
         this.svg = d3.select('#dependency-tree')
             .append('svg')
             .attr('width', width)
@@ -25,7 +28,7 @@ const TreeVisualizer = {
 
         // Create zoom behavior
         this.zoom = d3.zoom()
-            .scaleExtent([0.5, 3])
+            .scaleExtent([0.3, 3])
             .on('zoom', (event) => {
                 this.g.attr('transform', event.transform);
                 this.currentZoom = event.transform.k;
@@ -39,7 +42,7 @@ const TreeVisualizer = {
         // Convert dependencies to tree structure
         const root = this.buildTree(dependencies);
 
-        // Create tree layout
+        // Create tree layout with dynamic width
         const treeLayout = d3.tree()
             .size([width - 100, height - 150]);
 


### PR DESCRIPTION
- Add dynamic width for dependency tree and arc diagrams (scales with word count)
- Enable horizontal scrolling for long text passages
- Fix dark mode readability: make POS tag labels dark text on light background