### PR TITLE
feat(chatbot-evolution): add ELIZA memory display to breakdown tab

### DIFF
--- a/demos/chatbot-evolution/css/chatbot-evolution.css
+++ b/demos/chatbot-evolution/css/chatbot-evolution.css
@@ -1676,3 +1676,124 @@ a.paper-item:hover {
     display: block;
     margin-top: 4px;
 }
+
+/* Memory Display Styles (for ELIZA breakdown tab) */
+.memory-display-section {
+    margin-bottom: 20px;
+    padding: 15px;
+    background: var(--surface-color);
+    border: 2px solid var(--warning-color, #ffc107);
+    border-radius: 8px;
+}
+
+.memory-display-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 10px;
+}
+
+.memory-display-title {
+    font-weight: 600;
+    color: var(--warning-color, #ffc107);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.memory-empty {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-secondary);
+    font-style: italic;
+    padding: 10px;
+}
+
+.memory-empty-icon {
+    font-size: 1.2rem;
+}
+
+.memory-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.memory-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px;
+    background: var(--bg-secondary);
+    border-radius: 6px;
+    border-left: 3px solid var(--warning-color, #ffc107);
+}
+
+.memory-index {
+    width: 24px;
+    height: 24px;
+    background: var(--warning-color, #ffc107);
+    color: #000;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+.memory-text {
+    font-family: 'Monaco', 'Consolas', monospace;
+    font-size: 0.9rem;
+    color: var(--text-primary);
+}
+
+.memory-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 6px;
+    background: var(--warning-color, #ffc107);
+    color: #000;
+    border-radius: 4px;
+    font-size: 0.65rem;
+    font-weight: bold;
+    margin-right: 6px;
+    flex-shrink: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.memory-badge-header {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 6px;
+    background: var(--warning-color, #ffc107);
+    color: #000;
+    border-radius: 4px;
+    font-size: 0.65rem;
+    font-weight: bold;
+    margin-right: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    cursor: help;
+}
+
+.clear-memory-btn {
+    padding: 4px 10px;
+    background: transparent;
+    border: 1px solid var(--warning-color, #ffc107);
+    color: var(--warning-color, #ffc107);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    transition: var(--ce-transition);
+}
+
+.clear-memory-btn:hover {
+    background: var(--warning-color, #ffc107);
+    color: #000;
+}

--- a/demos/chatbot-evolution/index.html
+++ b/demos/chatbot-evolution/index.html
@@ -106,8 +106,25 @@
                                     <option value="Why do you ask that">Why do you ask that</option>
                                     <option value="Hello">Hello</option>
                                     <option value="I think computers are scary">I think computers are scary</option>
+                                    <option value="My dog is always happy">My dog is always happy (saves to memory)</option>
+                                    <option value="My job is stressful">My job is stressful (saves to memory)</option>
+                                    <option value="xyzzy gibberish">xyzzy gibberish (triggers xnone fallback)</option>
                                 </select>
                                 <button class="btn-analyze" onclick="analyzeEliza()">Analyze</button>
+                            </div>
+                            <div class="memory-display-section" id="eliza-memory-section">
+                                <div class="memory-display-header">
+                                    <div class="memory-display-title">
+                                        <span class="memory-badge-header" title="Patterns prefixed with $ save matching input to memory for later recall">mem</span> ELIZA's Memory
+                                    </div>
+                                    <button class="clear-memory-btn" id="eliza-clear-memory-btn">Clear Memory</button>
+                                </div>
+                                <div id="eliza-memory-display">
+                                    <div class="memory-empty">
+                                        <span class="memory-empty-icon">&#128173;</span>
+                                        <span>No memories stored</span>
+                                    </div>
+                                </div>
                             </div>
                             <div class="breakdown-steps" id="eliza-breakdown-steps">
                                 <div class="empty-state">

--- a/demos/chatbot-evolution/js/timeline-app.js
+++ b/demos/chatbot-evolution/js/timeline-app.js
@@ -58,7 +58,8 @@ class TimelineApp {
         this.currentEra = '2020s';
         
         this.elizaBreakdownRenderer = new ElizaBreakdownRenderer({
-            containerId: 'eliza-breakdown-steps'
+            containerId: 'eliza-breakdown-steps',
+            memoryDisplayId: 'eliza-memory-display'
         });
         
         this.rulesViewer = new RulesViewer('alice-rules-container');
@@ -268,6 +269,15 @@ class TimelineApp {
                 this.addMessage('gpt', 'Chat history cleared. Start a new conversation.', 'bot');
             });
         }
+
+        const elizaClearMemoryBtn = document.getElementById('eliza-clear-memory-btn');
+        if (elizaClearMemoryBtn) {
+            elizaClearMemoryBtn.addEventListener('click', async () => {
+                await this.bots.eliza.ensureInitialized();
+                this.bots.eliza.engine.clearMemory();
+                this.elizaBreakdownRenderer.renderMemoryStack();
+            });
+        }
     }
 
     switchChatbotTab(bot, tab) {
@@ -379,6 +389,12 @@ class TimelineApp {
         }
 
         this.elizaBreakdownRenderer.displayBreakdown(breakdown);
+
+        // Save to memory if this is a memory-save pattern (not a memory recall)
+        if (breakdown.shouldSave && !breakdown.usingMemory) {
+            this.bots.eliza.engine.saveToMemory(inputText);
+            this.elizaBreakdownRenderer.renderMemoryStack();
+        }
     }
 
     displayBreakdown(botName, breakdown) {


### PR DESCRIPTION
## Summary

Syncs the chatbot-evolution demo with the ELIZA memory features added in PR #58.

### Changes
- Add memory display section to ELIZA breakdown tab (matching standalone demo)
- Add memory-saving examples to dropdown ("My dog is always happy", "My job is stressful")
- Add xnone fallback example for testing memory recall
- Wire up memory save logic in `analyzeEliza()` method
- Add clear memory button handler
- Add memory-related CSS styles

### Testing
- All 144 ELIZA tests pass
- All chatbot tests pass